### PR TITLE
feature: added OptionBasedParser as well as NeedleTypeParser

### DIFF
--- a/parser_columns/option_based_parasers/base_option_from_group_parser.py
+++ b/parser_columns/option_based_parasers/base_option_from_group_parser.py
@@ -1,0 +1,16 @@
+from base_parser import BaseParser
+from utils.word_searcher import WordSearcher
+from typing import List
+
+class OptionBasedParser(BaseParser):
+    def __init__(self, options: List[str] = None):
+        self.word_searchers_list = [WordSearcher(word=option) for option in options]
+
+    def _get_matches_for_all_options(self, document_content: str) -> List[str]:
+        options_found_in_text = []
+        for word_searcher in self.word_searchers_list:
+            if (word_searcher.word in document_content) or (
+                    len(word_searcher.find_similar_words(document_content)) > 0):
+                options_found_in_text.append(word_searcher.word)
+        return sorted(options_found_in_text)
+

--- a/parser_columns/option_based_parasers/needle_type_parser.py
+++ b/parser_columns/option_based_parasers/needle_type_parser.py
@@ -1,0 +1,15 @@
+from constants import MISSING_VALUE
+from option_based_parasers.base_option_from_group_parser import OptionBasedParser
+
+NEEDLE_TYPES = ["Spinal", "Tuohy", "SMK", "RFK", "US"]
+
+class NeedleTypeParser(OptionBasedParser):
+    def __init__(self):
+        super().__init__(options=NEEDLE_TYPES)
+
+    def parse_document(self, document_content: str) -> str:
+        options_found_in_document = self._get_matches_for_all_options(document_content)
+        if len(options_found_in_document) == 0:
+            options_found_in_document.append(MISSING_VALUE)
+        sorted_options_found_in_document = sorted(options_found_in_document)
+        return ",".join(sorted_options_found_in_document)


### PR DESCRIPTION
added parser for needle type, original provided info:
![image](https://github.com/elad619/paintext/assets/58084279/0d6eae2c-8259-4a93-b8b4-77147675822f)

I run this over the first 5000 files and got the following:
![image](https://github.com/elad619/paintext/assets/58084279/0fc757f6-7467-4001-b34d-480a9953def7)


We should (when we get to think about post-processing of results) cross this with #4 (when no width exists -> there is no needle -> there is no needle type)